### PR TITLE
Torque load type

### DIFF
--- a/src/gui/properties.cpp
+++ b/src/gui/properties.cpp
@@ -141,6 +141,17 @@ void PropertiesTable::displayLoadcase(QString id) {
         createPropertyItem(++rowCount, 1, "vary");
         createVecValueItem(rowCount++, 2, f->vary);
     }
+    for (const Torque *t : load->torques) {
+        createNodeItem(rowCount, 0, "torque");
+        createPropertyItem(++rowCount, 1, "volume");
+        createValueItem(rowCount, 2, t->volume->id);
+        createPropertyItem(++rowCount, 1, "magnitude");
+        createVecValueItem(rowCount, 2, t->magnitude);
+        createPropertyItem(++rowCount, 1, "duration");
+        createValueItem(rowCount, 2, t->duration > 0 ? QString::number(t->duration) : "");
+        createPropertyItem(++rowCount, 1, "vary");
+        createVecValueItem(rowCount++, 2, t->vary);
+    }
     for (Actuation *a : load->actuations) {
         createNodeItem(rowCount, 0, "actuation");
         createPropertyItem(++rowCount, 1, "volume");

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -958,7 +958,7 @@ void Loader::applyLoadcase(Simulation *sim, Loadcase *load) {
             for (Mass *m : torque->masses) {
                 Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
                 Vec forceProjection = cross(torque->magnitude,distance)/distance.norm();
-                m->force =+ forceProjection;
+                m->force += forceProjection;
                 m->extforce += forceProjection;
             }
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -915,6 +915,60 @@ void Loader::applyLoadcase(Simulation *sim, Loadcase *load) {
             log(tr("Applied force to %1 masses with volume '%2'").arg(forceMasses).arg(forceVol->id));
     }
 
+    for (Torque *torque : load->torques) {
+        Volume *torqueVol = torque->volume;
+        qDebug() << "Applying Torque: " << torque->magnitude[0] << torque->magnitude[1] << torque->magnitude[2];
+
+        torque->masses.clear(); // Clear mass ptr cache
+
+        int torqueMasses = 0;
+        for (Mass *mass : sim->masses) {
+            glm::vec3 massPos = glm::vec3(mass->pos[0], mass->pos[1], mass->pos[2]);
+
+            // Check for force constraint
+            if (torqueVol->model != nullptr) {
+                if (torqueVol->model->isInside(massPos, 0)) {
+
+                    mass->extduration += torque->duration;
+
+                    if (mass->extduration < 0) {
+                        mass->extduration = DBL_MAX;
+                    }
+
+                    torque->masses.push_back(mass);
+                    torqueMasses++;
+                }
+
+            } else {
+                if (torqueVol->geometry->isInside(mass->pos)) {
+
+                    mass->extduration += torque->duration;
+
+                    if (mass->extduration < 0) {
+                        mass->extduration = DBL_MAX;
+                    }
+
+                    torque->masses.push_back(mass);
+                    torqueMasses++;
+                }
+            }
+        }
+        if (torqueMasses > 0) {
+            Vec torqueMag = torque->magnitude;
+            for (Mass *m : torque->masses) {
+                Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
+                Vec forceProjection = cross(torque->magnitude,distance)/norm(distance);
+                m->force =+ forceProjection;
+                m->extforce += forceProjection;
+            }
+
+
+            log(tr("Applied %3 N torque to %1 masses with volume '%2'").arg(torqueMasses).arg(torqueVol->id).arg(torqueMag.norm()));
+            cout << "Applied " << torqueMag.norm() << "N force to " << torqueMasses << " masses with volume " << torqueVol->id.toStdString() << ".\n";
+        } else
+            log(tr("Applied torque to %1 masses with volume '%2'").arg(torqueMasses).arg(torqueVol->id));
+    }
+
     for (Actuation *actuation : load->actuations) {
         Volume *actVol = actuation->volume;
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -957,7 +957,7 @@ void Loader::applyLoadcase(Simulation *sim, Loadcase *load) {
             Vec torqueMag = torque->magnitude;
             for (Mass *m : torque->masses) {
                 Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
-                Vec forceProjection = cross(torque->magnitude,distance)/norm(distance);
+                Vec forceProjection = cross(torque->magnitude,distance)/distance.norm();
                 m->force =+ forceProjection;
                 m->extforce += forceProjection;
             }

--- a/src/model.h
+++ b/src/model.h
@@ -33,6 +33,7 @@ class Volume;
 class Material;
 class Anchor;
 class Force;
+class Torque;
 class Loadcase;
 class LatticeConfig;
 
@@ -795,6 +796,21 @@ public:
     vector<Mass *> masses;
 };
 
+class Torque
+{
+public:
+    Torque() {}
+    ~Torque() {}
+
+    Volume * volume;
+    Vec magnitude;
+    double duration;
+    Vec vary;
+    Vec origin; 
+
+    vector<Mass *> masses;
+};
+
 class Actuation
 {
 public:
@@ -838,6 +854,9 @@ public:
 
     vector<Force *> forces;
     map<QString, Force *> forceMap;
+
+    vector<Torque *> torques;
+    map<QString, Torque *> torqueMap;
 
     vector<Actuation *> actuations;
     map<QString, Actuation *> actuationMap;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -179,7 +179,30 @@ void Parser::parseLoadcase(pugi::xml_node dml_load, Loadcase *loadcase, Design *
         loadcase->forceMap[volume] = force;
         std::cout << "\tForce '" << volume.toStdString() << "' PARSED\n";
     }
+    // TORQUES
+    for (pugi::xml_node frc : dml_load.children("torque")) {
+        Torque *torque = new Torque();
+        QString volume = frc.attribute("volume").value();
+        Vec magnitude = parseVec(frc.attribute("magnitude").value());
+        double duration = frc.attribute("duration").as_double(-1);
+        Vec vary = parseVec(frc.attribute("vary").value());
+        Vec origin = parseVec(frc.attribute("origin").value());
 
+        torque->volume = design->volumeMap[volume];
+        if (!(torque->volume)) {
+            cerr << "Volume '" << volume.toStdString() << "' not found.";
+            exit(EXIT_FAILURE);
+        }
+        torque->magnitude = magnitude;
+        torque->duration = duration;
+        torque->vary = vary;
+        torque->origin = origin;
+
+        loadcase->torques.push_back(torque);
+        loadcase->torqueMap[volume] = torque;
+        std::cout << "\tTorque '" << volume.toStdString() << "' PARSED\n";
+    }
+    
     loadcase->id = id;
     loadcase->totalDuration = 0;
 }

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -1008,14 +1008,14 @@ void Simulator::applyLoad(Loadcase *load) {
             }
         }
     }
-    for (Torque *f : load->torques) {
+    for (Torque *t : load->torques) {
         int torqueMasses = 0;
 
-        for (Mass *fm : f->masses) {
+        for (Mass *tm : t->masses) {
             bool valid = false;
             for (Mass *m : sim->masses) {
-                    if (m == fm) {
-                    m->extduration = f->duration + pastLoadTime;
+                    if (m == tm) {
+                    m->extduration = t->duration + pastLoadTime;
                     qDebug() << "DURATION" << m->extduration;
                     if (m->extduration < 0) {
                         m->extduration = DBL_MAX;
@@ -1025,14 +1025,14 @@ void Simulator::applyLoad(Loadcase *load) {
                 }
             }
             if (!valid) {
-                f->masses.erase(remove(f->masses.begin(), f->masses.end(), fm), f->masses.end());
+                t->masses.erase(remove(t->masses.begin(), t->masses.end(), tm), t->masses.end());
             }
         }
         if (torqueMasses > 0) {
-            Vec torqueMag = f->magnitude / torqueMasses;
-            for (Mass *fm : f->masses) {
-                Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
-                Vec forceProjection = cross(torque->magnitude,distance)/distance.norm();
+            Vec torqueMag = t->magnitude / torqueMasses;
+            for (Mass *m : t->masses) {
+                Vec distance = Vec(t->origin[0]-m->pos[0] , t->origin[1]-m->pos[1] , t->origin[2]-m->pos[2]);
+                Vec forceProjection = cross(t->magnitude,distance)/distance.norm();
                 m->force += forceProjection;
                 m->extforce += forceProjection;
             }

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -1032,8 +1032,8 @@ void Simulator::applyLoad(Loadcase *load) {
             Vec torqueMag = f->magnitude / torqueMasses;
             for (Mass *fm : f->masses) {
                 Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
-                Vec forceProjection = cross(torque->magnitude,distance)/norm(distance);
-                m->force =+ forceProjection;
+                Vec forceProjection = cross(torque->magnitude,distance)/distance.norm();
+                m->force += forceProjection;
                 m->extforce += forceProjection;
             }
         }

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -1008,6 +1008,36 @@ void Simulator::applyLoad(Loadcase *load) {
             }
         }
     }
+    for (Torque *f : load->torques) {
+        int torqueMasses = 0;
+
+        for (Mass *fm : f->masses) {
+            bool valid = false;
+            for (Mass *m : sim->masses) {
+                    if (m == fm) {
+                    m->extduration = f->duration + pastLoadTime;
+                    qDebug() << "DURATION" << m->extduration;
+                    if (m->extduration < 0) {
+                        m->extduration = DBL_MAX;
+                    }
+                    torqueMasses ++;
+                    valid = true;
+                }
+            }
+            if (!valid) {
+                f->masses.erase(remove(f->masses.begin(), f->masses.end(), fm), f->masses.end());
+            }
+        }
+        if (torqueMasses > 0) {
+            Vec torqueMag = f->magnitude / torqueMasses;
+            for (Mass *fm : f->masses) {
+                Vec distance = Vec(torque->origin[0]-m->pos[0] , torque->origin[1]-m->pos[1] , torque->origin[2]-m->pos[2]);
+                Vec forceProjection = cross(torque->magnitude,distance)/norm(distance);
+                m->force =+ forceProjection;
+                m->extforce += forceProjection;
+            }
+        }
+    }
     sim->setAll();
 }
 


### PR DESCRIPTION
Allows the ability to enter torque load cases defined by a Geometry bounding, and torque about an origin point.

Usage: 

		<torque volume="torque_beam" magnitude="100, 0, 0" origin="0,0,0" /> 

Notes: 

- If no origin is set, default will be 0,0,0 and the projected force of the torque will be applied appropriately
- Torque loads are set to be positive in the clockwise direction (as is typical norm) about the xyz axis 
- Torque is calculated using the cross product definition T = r x F, where r is the distance vector from the origin point to the point mass, this is solved for the projected force to be defined F = T x r / |r|^2, also stated F = cross(T,r)/norm(r)
